### PR TITLE
Refactor SMS flow with guided intro and inline event selection

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -23,6 +23,7 @@ body {
     color: var(--dark-gray);
     background: linear-gradient(135deg, var(--light-gray) 0%, #e5e7eb 100%);
     min-height: 100vh;
+    position: relative;
 }
 
 .header {
@@ -73,6 +74,10 @@ body {
     margin-bottom: 2rem;
 }
 
+.card.intro-card {
+    max-width: 640px;
+}
+
 .card-header {
     background: linear-gradient(135deg, var(--dark-gray) 0%, #374151 100%);
     color: var(--white);
@@ -107,6 +112,23 @@ body {
     flex-direction: column;
 }
 
+.form-section {
+    margin-bottom: 2rem;
+}
+
+.form-section h3 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+    color: var(--dark-gray);
+}
+
+.form-section p.section-description {
+    color: var(--text-gray);
+    font-size: 0.9rem;
+    margin-bottom: 1.25rem;
+}
+
 .form-group.full-width {
     grid-column: 1 / -1;
 }
@@ -120,6 +142,25 @@ label {
 
 .required {
     color: var(--accent-red);
+}
+
+.optional-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    background: var(--light-gray);
+    border-radius: 999px;
+    padding: 0.15rem 0.6rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--text-gray);
+    margin-left: 0.5rem;
+}
+
+.microcopy {
+    font-size: 0.78rem;
+    color: var(--text-gray);
+    margin-top: 0.35rem;
 }
 
 input, select, textarea {
@@ -200,6 +241,64 @@ textarea {
     font-size: 0.85rem;
     color: var(--text-gray);
     line-height: 1.4;
+}
+
+.area-card .area-description {
+    margin-bottom: 1rem;
+}
+
+.subtype-panel {
+    border-top: 1px solid var(--border-gray);
+    margin-top: 1rem;
+    padding-top: 1rem;
+    display: none;
+    text-align: left;
+}
+
+.subtype-panel.active {
+    display: block;
+}
+
+.subtype-panel h4 {
+    font-size: 0.95rem;
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+    color: var(--dark-gray);
+}
+
+.subtype-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0.75rem;
+}
+
+.subtype-option {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    border: 1px solid var(--border-gray);
+    border-radius: 8px;
+    padding: 0.75rem;
+    cursor: pointer;
+    background: var(--white);
+    font-size: 0.85rem;
+    text-align: left;
+    transition: all 0.2s ease;
+}
+
+.subtype-option:hover {
+    border-color: var(--secondary-blue);
+    box-shadow: 0 3px 12px rgba(59,130,246,0.15);
+}
+
+.subtype-option.selected {
+    border-color: var(--accent-red);
+    box-shadow: 0 0 0 2px rgba(220,38,38,0.15);
+}
+
+.subtype-option span {
+    font-weight: 600;
+    color: var(--dark-gray);
 }
 
 .btn {
@@ -312,5 +411,160 @@ textarea {
 
 input.invalid {
     border-color: red;
+}
+
+/* Intro overlay */
+.intro-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.6);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    z-index: 2000;
+    backdrop-filter: blur(4px);
+}
+
+.intro-overlay.show {
+    display: flex;
+}
+
+.intro-dialog {
+    background: var(--white);
+    border-radius: 16px;
+    max-width: 720px;
+    width: min(100%, 720px);
+    box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.45);
+    overflow: hidden;
+    animation: modalFadeIn 0.3s ease;
+}
+
+.intro-dialog header {
+    background: linear-gradient(135deg, var(--primary-blue) 0%, var(--secondary-blue) 100%);
+    color: var(--white);
+    padding: 1.75rem 2rem;
+}
+
+.intro-dialog header h2 {
+    font-size: 1.6rem;
+    font-weight: 600;
+}
+
+.intro-dialog header p {
+    margin-top: 0.35rem;
+    font-size: 0.95rem;
+    opacity: 0.9;
+}
+
+.intro-dialog .intro-body {
+    padding: 2rem;
+}
+
+.steps-list {
+    display: grid;
+    gap: 1rem;
+    margin-bottom: 2rem;
+}
+
+.step-item {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-start;
+}
+
+.step-number {
+    width: 36px;
+    height: 36px;
+    border-radius: 12px;
+    background: rgba(59,130,246,0.15);
+    color: var(--primary-blue);
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.step-text strong {
+    display: block;
+    font-size: 0.95rem;
+    color: var(--dark-gray);
+}
+
+.step-text span {
+    font-size: 0.85rem;
+    color: var(--text-gray);
+}
+
+.intro-actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.btn-secondary {
+    background: var(--text-gray);
+}
+
+.btn-secondary:hover {
+    background: #111827;
+}
+
+@keyframes modalFadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(12px) scale(0.96);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+/* Guided narrative blocks */
+.guided-blocks {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.guided-block {
+    background: rgba(59,130,246,0.08);
+    border: 1px solid rgba(59,130,246,0.2);
+    border-radius: 12px;
+    padding: 1.25rem;
+}
+
+.guided-block h3 {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 0.35rem;
+}
+
+.guided-block p {
+    font-size: 0.85rem;
+    color: var(--text-gray);
+    margin-bottom: 0.75rem;
+}
+
+.guided-block textarea,
+.guided-block input {
+    border-color: rgba(59,130,246,0.35);
+}
+
+.guided-block textarea.invalid,
+.guided-block input.invalid {
+    border-color: var(--accent-red);
+    box-shadow: 0 0 0 3px rgba(220,38,38,0.1);
+}
+
+@media (max-width: 768px) {
+    .intro-dialog header,
+    .intro-dialog .intro-body {
+        padding: 1.5rem;
+    }
+
+    .step-item {
+        align-items: center;
+    }
 }
 

--- a/flight.html
+++ b/flight.html
@@ -6,214 +6,36 @@
     <title>Formulario Específico - Operaciones de Vuelo</title>
     <link rel="stylesheet" href="css/styles.css">
     <style>
-        /* Estilos para la selección de áreas en grid normal */
         .area-selection {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 1rem;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 1.25rem;
         }
 
         .area-card {
-            background: #f8fafc;
-            border: 2px solid #e2e8f0;
-            border-radius: 8px;
-            padding: 1.5rem;
-            text-align: center;
-            cursor: pointer;
-            transition: all 0.3s ease;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .area-card:hover {
-            border-color: #3b82f6;
-            box-shadow: 0 4px 15px rgba(59, 130, 246, 0.2);
-            transform: translateY(-2px);
+            text-align: left;
+            align-items: flex-start;
         }
 
         .area-card.selected {
-            border-color: #3b82f6;
-            background: #dbeafe;
+            box-shadow: 0 12px 30px -12px rgba(30,58,138,0.45);
         }
 
-        .area-icon {
-            font-size: 2.5rem;
-            margin-bottom: 1rem;
-        }
-
-        .area-title {
-            font-weight: 600;
-            font-size: 1.1rem;
-            margin-bottom: 1rem;
-        }
-
-        /* Estilos para el modal/pop-up */
-        .modal-overlay {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: rgba(0, 0, 0, 0.5);
-            backdrop-filter: blur(4px);
-            display: none;
-            align-items: center;
-            justify-content: center;
-            z-index: 1000;
-        }
-
-        .modal-overlay.show {
-            display: flex;
-        }
-
-        .modal-content {
-            background: white;
-            border-radius: 12px;
-            padding: 2rem;
-            max-width: 500px;
-            width: 90%;
-            max-height: 80vh;
-            overflow-y: auto;
-            position: relative;
-            box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
-        }
-
-        .modal-header {
-            text-align: center;
-            margin-bottom: 2rem;
-        }
-
-        .modal-icon {
-            font-size: 3rem;
-            margin-bottom: 1rem;
-        }
-
-        .modal-title {
-            font-size: 1.5rem;
-            font-weight: 600;
-            color: #1f2937;
-            margin-bottom: 0.5rem;
-        }
-
-        .modal-subtitle {
-            color: #6b7280;
-            font-size: 0.95rem;
-        }
-
-        .close-button {
-            position: absolute;
-            top: 1rem;
-            right: 1rem;
-            background: #f3f4f6;
-            border: 1px solid #d1d5db;
-            border-radius: 50%;
-            width: 36px;
-            height: 36px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            cursor: pointer;
-            color: #6b7280;
-            font-size: 1.2rem;
-            transition: all 0.2s ease;
-        }
-
-        .close-button:hover {
-            background: #e5e7eb;
-            color: #374151;
-        }
-
-        .form-group {
-            margin-bottom: 2rem;
-        }
-
-        .form-group label {
-            display: block;
+        .subtype-message {
+            font-size: 0.85rem;
+            color: var(--text-gray);
             margin-bottom: 0.75rem;
-            font-weight: 600;
-            color: #374151;
-            font-size: 1rem;
         }
 
-        .form-group select {
-            width: 100%;
-            padding: 0.875rem;
-            border: 2px solid #d1d5db;
-            border-radius: 8px;
-            background: white;
-            color: #374151;
-            font-size: 1rem;
-            transition: border-color 0.2s ease;
-        }
-
-        .form-group select:focus {
-            outline: none;
-            border-color: #3b82f6;
-            box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
-        }
-
-        .required {
-            color: #ef4444;
-        }
-
-        .modal-actions {
+        .direct-hint {
             display: flex;
-            gap: 1rem;
-            justify-content: flex-end;
-            margin-top: 2rem;
-            padding-top: 1.5rem;
-            border-top: 1px solid #e5e7eb;
-        }
-
-        .modal-btn {
-            padding: 0.75rem 1.5rem;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 0.85rem;
+            color: var(--primary-blue);
+            padding: 0.75rem;
+            background: rgba(59,130,246,0.12);
             border-radius: 8px;
-            font-weight: 500;
-            cursor: pointer;
-            transition: all 0.2s ease;
-            border: none;
-            font-size: 0.95rem;
-        }
-
-        .modal-btn-cancel {
-            background: var(--text-gray);
-            color: var(--white);
-        }
-
-        .modal-btn-cancel:hover {
-            opacity: 0.9;
-        }
-
-        .modal-btn-primary {
-            background: var(--primary-blue);
-            color: var(--white);
-        }
-
-        .modal-btn-primary:hover:not(:disabled) {
-            background: var(--primary-blue-hover);
-        }
-
-        .modal-btn-primary:disabled {
-            background: #9ca3af;
-            cursor: not-allowed;
-        }
-
-        /* Animación de entrada */
-        .modal-content {
-            animation: modalFadeIn 0.3s ease-out;
-        }
-
-        @keyframes modalFadeIn {
-            from {
-                opacity: 0;
-                transform: scale(0.9) translateY(-10px);
-            }
-            to {
-                opacity: 1;
-                transform: scale(1) translateY(0);
-            }
         }
     </style>
 </head>
@@ -241,7 +63,7 @@
         <div class="card">
             <div class="card-header">
                 <h2>¿Qué tipo de evento ocurrió durante la Operación de Vuelo?</h2>
-                <p>Seleccione la opción que mejor describe lo que desea reportar</p>
+                <p>Selecciona la categoría y, si aplica, el subtipo correspondiente sin salir de esta vista.</p>
             </div>
 
             <div class="card-body">
@@ -253,41 +75,146 @@
                     <div class="area-card" data-event="tcas_gpws" title="Alertas de proximidad, tráfico aéreo y terreno">
                         <div class="area-icon">⚠️</div>
                         <div class="area-title">Advertencias TCAS/GPWS</div>
+                        <div class="area-description">Alertas con tráfico o terreno que requieren atención inmediata.</div>
+                        <div class="subtype-panel" data-panel="tcas_gpws">
+                            <h4>Selecciona el subtipo</h4>
+                            <p class="subtype-message">Elige el escenario que mejor describe la advertencia recibida.</p>
+                            <div class="subtype-grid">
+                                <button type="button" class="subtype-option" data-subtype="tcas_ta">
+                                    <span>TCAS TA</span>
+                                    <small>Alerta de tráfico preventivo.</small>
+                                </button>
+                                <button type="button" class="subtype-option" data-subtype="tcas_ra">
+                                    <span>TCAS RA</span>
+                                    <small>Alerta con maniobra de resolución.</small>
+                                </button>
+                                <button type="button" class="subtype-option" data-subtype="gpws">
+                                    <span>GPWS</span>
+                                    <small>Advertencia de proximidad al terreno.</small>
+                                </button>
+                                <button type="button" class="subtype-option" data-subtype="other_tcas">
+                                    <span>Otro</span>
+                                    <small>Advertencia distinta no listada.</small>
+                                </button>
+                            </div>
+                        </div>
                     </div>
 
                     <div class="area-card" data-event="unstable_approach" title="Aproximación inestable o sobrepaso">
                         <div class="area-icon">🛬</div>
                         <div class="area-title">Aproximación y Contacto Anormal con la Pista</div>
+                        <div class="area-description">Eventos durante aproximación, go around o contacto con pista.</div>
+                        <div class="subtype-panel" data-panel="unstable_approach">
+                            <h4>Selecciona el subtipo</h4>
+                            <p class="subtype-message">Detalla qué situación se presentó en la aproximación o aterrizaje.</p>
+                            <div class="subtype-grid">
+                                <button type="button" class="subtype-option" data-subtype="unstable_landing">
+                                    <span>Aproximación inestable</span>
+                                    <small>Continuación a pesar de parámetros fuera de tolerancia.</small>
+                                </button>
+                                <button type="button" class="subtype-option" data-subtype="goaround">
+                                    <span>Go Around</span>
+                                    <small>Procedimiento de aproximación frustrada.</small>
+                                </button>
+                                <button type="button" class="subtype-option" data-subtype="abnormal_contact">
+                                    <span>Contacto anormal</span>
+                                    <small>Golpe duro, rebote o excursión parcial.</small>
+                                </button>
+                            </div>
+                        </div>
                     </div>
 
                     <div class="area-card" data-event="adverse_weather" title="Condiciones meteorológicas adversas">
                         <div class="area-icon">🌩️</div>
                         <div class="area-title">Condiciones Meteorológicas</div>
+                        <div class="area-description">Fenómenos que afectaron la operación del vuelo.</div>
+                        <div class="subtype-panel" data-panel="adverse_weather">
+                            <h4>Selecciona el subtipo</h4>
+                            <p class="subtype-message">Describe la condición que impactó el vuelo.</p>
+                            <div class="subtype-grid">
+                                <button type="button" class="subtype-option" data-subtype="turbulence">
+                                    <span>Turbulencia</span>
+                                    <small>Moderada, severa o inesperada.</small>
+                                </button>
+                                <button type="button" class="subtype-option" data-subtype="storm">
+                                    <span>Tormenta</span>
+                                    <small>Lluvia intensa o actividad eléctrica.</small>
+                                </button>
+                                <button type="button" class="subtype-option" data-subtype="hail">
+                                    <span>Granizo</span>
+                                    <small>Impacto de partículas de hielo.</small>
+                                </button>
+                                <button type="button" class="subtype-option" data-subtype="windshear">
+                                    <span>Windshear</span>
+                                    <small>Cizalladura de viento detectada o sospechada.</small>
+                                </button>
+                                <button type="button" class="subtype-option" data-subtype="low_visibility">
+                                    <span>Baja visibilidad</span>
+                                    <small>Niebla, humo, polvo u otra reducción.</small>
+                                </button>
+                                <button type="button" class="subtype-option" data-subtype="other_weather">
+                                    <span>Otro</span>
+                                    <small>Condición no listada.</small>
+                                </button>
+                            </div>
+                        </div>
                     </div>
 
                     <div class="area-card" data-event="bird_strike" title="Bird strikes durante operaciones">
                         <div class="area-icon">🐦</div>
                         <div class="area-title">Impacto con Aves</div>
+                        <div class="area-description">Colisión o contacto con fauna durante cualquier fase.</div>
+                        <div class="subtype-panel" data-panel="bird_strike">
+                            <div class="direct-hint">Selección directa. Continúa para describir los detalles.</div>
+                        </div>
                     </div>
 
                     <div class="area-card" data-event="crew_fatigue" title="Eventos relacionados con fatiga operacional">
                         <div class="area-icon">😴</div>
                         <div class="area-title">Fatiga de Tripulación</div>
+                        <div class="area-description">Cansancio acumulado o eventos relacionados al descanso.</div>
+                        <div class="subtype-panel" data-panel="crew_fatigue">
+                            <h4>Selecciona el subtipo</h4>
+                            <p class="subtype-message">Identifica cómo se originó el evento de fatiga.</p>
+                            <div class="subtype-grid">
+                                <button type="button" class="subtype-option" data-subtype="scheduled_assignment">
+                                    <span>Asignación programada</span>
+                                    <small>Fatiga anticipada antes de ejecutar la tarea.</small>
+                                </button>
+                                <button type="button" class="subtype-option" data-subtype="executed_assignment">
+                                    <span>Asignación ejecutada</span>
+                                    <small>Fatiga manifiesta durante o posterior al servicio.</small>
+                                </button>
+                                <button type="button" class="subtype-option" data-subtype="other_fatigue">
+                                    <span>Otro</span>
+                                    <small>Situación distinta no listada.</small>
+                                </button>
+                            </div>
+                        </div>
                     </div>
 
                     <div class="area-card" data-event="technical_failure" title="Fallas técnicas de la aeronave">
                         <div class="area-icon">🔧</div>
                         <div class="area-title">Falla Técnica</div>
+                        <div class="area-description">Sistemas, componentes o instrumentos fuera de servicio.</div>
+                        <div class="subtype-panel" data-panel="technical_failure">
+                            <div class="direct-hint">Selección directa. Ampliaremos la información en los siguientes pasos.</div>
+                        </div>
                     </div>
 
                     <div class="area-card" data-event="runway_incursion" title="Incursión en pista/calle de rodaje">
                         <div class="area-icon">🚨</div>
                         <div class="area-title">Incursión en Pista</div>
+                        <div class="area-description">Intrusión no autorizada en pista o calle de rodaje.</div>
+                        <div class="subtype-panel" data-panel="runway_incursion">
+                            <div class="direct-hint">Selección directa. Detallaremos la incursión en el formulario.</div>
+                        </div>
                     </div>
 
                     <div class="area-card" data-event="other" title="Otros eventos no especificados">
                         <div class="area-icon">❓</div>
                         <div class="area-title">Otro</div>
+                        <div class="area-description">Cuando ninguna categoría representa lo ocurrido.</div>
                     </div>
                 </div>
             </div>
@@ -297,31 +224,9 @@
         <div class="card">
             <div class="card-body">
                 <div class="form-actions">
-                    <button type="button" class="btn" onclick="history.back()" style="background: var(--text-gray); color: var(--white);">Regresar</button>
-                    <button type="button" class="btn" id="nextPageBtn" disabled style="display: none;">Continuar al Formulario Específico</button>
+                    <button type="button" class="btn btn-secondary" onclick="history.back()">Regresar</button>
+                    <button type="button" class="btn" id="nextPageBtn" disabled>Continuar</button>
                 </div>
-            </div>
-        </div>
-    </div>
-
-    <!-- Modal Pop-up -->
-    <div class="modal-overlay" id="modalOverlay">
-        <div class="modal-content">
-            <button class="close-button" id="closeModal">×</button>
-            
-            <div class="modal-header">
-                <div class="modal-icon" id="modalIcon"></div>
-                <div class="modal-title" id="modalTitle"></div>
-                <div class="modal-subtitle" id="modalSubtitle"></div>
-            </div>
-
-            <div id="modalFormContent">
-                <!-- El contenido del formulario se insertará dinámicamente aquí -->
-            </div>
-
-            <div class="modal-actions">
-                <button class="modal-btn modal-btn-cancel" id="cancelModal">Cancelar</button>
-                <button class="modal-btn modal-btn-primary" id="confirmModal" disabled>Continuar al Formulario Específico</button>
             </div>
         </div>
     </div>
@@ -331,7 +236,6 @@
             constructor() {
                 this.selectedEventType = null;
                 this.selectedSubEvent = null;
-                this.currentModalData = null;
                 this.init();
             }
 
@@ -339,8 +243,8 @@
                 const progressFill = document.getElementById('progressFill');
                 if (progressFill) progressFill.style.width = '33.33%';
 
-                this.bindEvents();
                 this.setupPageRoutes();
+                this.bindEvents();
             }
 
             setupPageRoutes() {
@@ -376,190 +280,88 @@
 
                 // Eventos que no requieren subselección
                 this.directEvents = ['bird_strike', 'technical_failure', 'runway_incursion', 'other'];
-
-                // Configuración de modales por tipo de evento
-                this.modalConfigs = {
-                    'tcas_gpws': {
-                        icon: '⚠️',
-                        title: 'Advertencias TCAS/GPWS',
-                        subtitle: 'Seleccione el tipo específico de advertencia',
-                        options: [
-                            { value: 'tcas_ta', label: 'Alerta de tráfico (TCAS TA)' },
-                            { value: 'tcas_ra', label: 'Alerta de resolución (TCAS RA)' },
-                            { value: 'gpws', label: 'Alerta de proximidad al terreno (GPWS)' },
-                            { value: 'other_tcas', label: 'Otro' }
-                        ]
-                    },
-                    'unstable_approach': {
-                        icon: '🛬',
-                        title: 'Aproximación y Contacto Anormal con la Pista',
-                        subtitle: 'Seleccione el tipo específico de evento',
-                        options: [
-                            { value: 'unstable_landing', label: 'Aproximación inestable con Aterrizaje' },
-                            { value: 'goaround', label: 'Sobrepaso' },
-                            { value: 'abnormal_contact', label: 'Contacto Anormal con la Pista' }
-                        ]
-                    },
-                    'adverse_weather': {
-                        icon: '🌩️',
-                        title: 'Condiciones Meteorológicas',
-                        subtitle: 'Seleccione el tipo de condición meteorológica',
-                        options: [
-                            { value: 'turbulence', label: 'Turbulencia' },
-                            { value: 'storm', label: 'Tormenta (lluvia, truenos o actividad eléctrica)' },
-                            { value: 'hail', label: 'Granizo' },
-                            { value: 'windshear', label: 'Cizalladura de viento - Windshear' },
-                            { value: 'low_visibility', label: 'Reducción de visibilidad (niebla, polvo, etc)' },
-                            { value: 'other_weather', label: 'Otro' }
-                        ]
-                    },
-                    'crew_fatigue': {
-                        icon: '😴',
-                        title: 'Fatiga de Tripulación',
-                        subtitle: 'Seleccione el tipo específico de fatiga',
-                        options: [
-                            { value: 'scheduled_assignment', label: 'Asignación programada' },
-                            { value: 'executed_assignment', label: 'Asignación Ejecutada' },
-                            { value: 'other_fatigue', label: 'Otro' }
-                        ]
-                    }
-                };
             }
 
             bindEvents() {
                 // Eventos para las tarjetas de área
                 document.querySelectorAll('.area-card[data-event]').forEach(card => {
-                    card.addEventListener('click', () => this.selectEventType(card));
+                    card.addEventListener('click', (event) => {
+                        // evitar que botones internos disparen la selección
+                        if (event.target.closest('.subtype-option')) return;
+                        this.selectEventType(card.dataset.event);
+                    });
                 });
 
-                // Eventos del modal
-                document.getElementById('closeModal').addEventListener('click', () => this.closeModal());
-                document.getElementById('cancelModal').addEventListener('click', () => this.closeModal());
-                document.getElementById('confirmModal').addEventListener('click', () => this.confirmSelection());
-                
-                // Cerrar modal al hacer click en el overlay
-                document.getElementById('modalOverlay').addEventListener('click', (e) => {
-                    if (e.target === document.getElementById('modalOverlay')) {
-                        this.closeModal();
-                    }
+                document.querySelectorAll('.subtype-option').forEach(option => {
+                    option.addEventListener('click', (event) => {
+                        event.stopPropagation();
+                        this.selectSubtype(option.dataset.subtype, option);
+                    });
                 });
 
-                // Evento del botón continuar principal
                 const nextBtn = document.getElementById('nextPageBtn');
                 if (nextBtn) {
                     nextBtn.addEventListener('click', () => this.navigateToSpecificForm());
                 }
             }
 
-            selectEventType(selectedCard) {
-                const eventType = selectedCard.dataset.event;
-                
+            selectEventType(eventType) {
+                this.selectedEventType = eventType;
+                if (this.directEvents.includes(eventType)) {
+                    this.selectedSubEvent = eventType;
+                } else {
+                    this.selectedSubEvent = null;
+                }
+
                 // Actualizar selección visual
                 document.querySelectorAll('.area-card').forEach(card => {
                     card.classList.remove('selected');
                 });
-                selectedCard.classList.add('selected');
+                const activeCard = document.querySelector(`.area-card[data-event="${eventType}"]`);
+                if (activeCard) activeCard.classList.add('selected');
 
-                // Especial handling para "other"
+                // Mostrar panel correspondiente
+                document.querySelectorAll('.subtype-panel').forEach(panel => {
+                    panel.classList.remove('active');
+                });
+                const panel = document.querySelector(`.subtype-panel[data-panel="${eventType}"]`);
+                if (panel) panel.classList.add('active');
+
+                // Reset selección de subtipo visual
+                document.querySelectorAll('.subtype-option').forEach(option => {
+                    option.classList.remove('selected');
+                });
+
+                // Evento "otro" navega directo
                 if (eventType === 'other') {
                     this.navigateDirectlyToOther();
                     return;
                 }
 
-                // Si es un evento directo, proceder inmediatamente
-                if (this.directEvents.includes(eventType)) {
-                    this.selectedEventType = eventType;
-                    this.selectedSubEvent = eventType;
-                    this.showContinueButton();
-                    return;
-                }
-
-                // Si requiere subselección, mostrar modal
-                if (this.modalConfigs[eventType]) {
-                    this.showModal(eventType);
-                }
+                this.updateContinueState();
             }
 
-            showModal(eventType) {
-                const config = this.modalConfigs[eventType];
-                this.currentModalData = { eventType, config };
-                
-                // Configurar contenido del modal
-                document.getElementById('modalIcon').textContent = config.icon;
-                document.getElementById('modalTitle').textContent = config.title;
-                document.getElementById('modalSubtitle').textContent = config.subtitle;
-                
-                // Crear el formulario
-                const formContent = document.getElementById('modalFormContent');
-                formContent.innerHTML = `
-                    <div class="form-group">
-                        <label for="modalSelect">Detalle Específico <span class="required">*</span></label>
-                        <select id="modalSelect">
-                            <option value="">Seleccione...</option>
-                            ${config.options.map(option => 
-                                `<option value="${option.value}">${option.label}</option>`
-                            ).join('')}
-                        </select>
-                    </div>
-                `;
-
-                // Bind evento del select
-                document.getElementById('modalSelect').addEventListener('change', (e) => {
-                    const confirmBtn = document.getElementById('confirmModal');
-                    confirmBtn.disabled = !e.target.value;
+            selectSubtype(subtype, element) {
+                this.selectedSubEvent = subtype;
+                document.querySelectorAll('.subtype-option').forEach(option => {
+                    option.classList.remove('selected');
                 });
-
-                // Mostrar modal
-                document.getElementById('modalOverlay').classList.add('show');
-                
-                // Reset del botón confirmar
-                document.getElementById('confirmModal').disabled = true;
+                element.classList.add('selected');
+                this.updateContinueState();
             }
 
-            showContinueButton() {
+            updateContinueState() {
                 const nextBtn = document.getElementById('nextPageBtn');
-                if (nextBtn) {
-                    nextBtn.style.display = 'inline-block';
-                    nextBtn.disabled = false;
-                }
-                
-                // Ocultar error si existía
                 const eventTypeError = document.getElementById('eventTypeError');
-                if (eventTypeError) eventTypeError.style.display = 'none';
-            }
+                if (!nextBtn) return;
 
-            hideContinueButton() {
-                const nextBtn = document.getElementById('nextPageBtn');
-                if (nextBtn) {
-                    nextBtn.style.display = 'none';
-                    nextBtn.disabled = true;
+                const isDirect = this.directEvents.includes(this.selectedEventType);
+                const canContinue = Boolean(this.selectedEventType) && (isDirect || this.selectedSubEvent);
+
+                nextBtn.disabled = !canContinue;
+                if (eventTypeError && canContinue) {
+                    eventTypeError.style.display = 'none';
                 }
-            }
-
-            closeModal() {
-                document.getElementById('modalOverlay').classList.remove('show');
-                this.currentModalData = null;
-                
-                // Limpiar selección visual si no hay selección confirmada
-                if (!this.selectedEventType) {
-                    document.querySelectorAll('.area-card').forEach(card => {
-                        card.classList.remove('selected');
-                    });
-                    this.hideContinueButton();
-                }
-            }
-
-            confirmSelection() {
-                if (!this.currentModalData) return;
-
-                const selectedValue = document.getElementById('modalSelect').value;
-                if (!selectedValue) return;
-
-                this.selectedEventType = this.currentModalData.eventType;
-                this.selectedSubEvent = selectedValue;
-                
-                // Navegar directamente al formulario específico
-                this.navigateToSpecificForm();
             }
 
             navigateDirectlyToOther() {
@@ -573,28 +375,20 @@
             }
 
             validateForm() {
-                const nextBtn = document.getElementById('nextPageBtn');
-                let isValid = false;
-
-                if (!this.selectedEventType) {
-                    isValid = false;
-                } else if (this.directEvents.includes(this.selectedEventType)) {
-                    // Eventos que no requieren subselección - el botón ya está visible
-                    return true;
-                } else {
-                    // Eventos que requieren subselección - no mostrar el botón base
-                    isValid = this.selectedSubEvent && this.selectedSubEvent !== '';
-                    if (nextBtn) {
-                        nextBtn.style.display = 'none';
-                        nextBtn.disabled = true;
-                    }
-                }
-
-                return isValid;
+                if (!this.selectedEventType) return false;
+                if (this.directEvents.includes(this.selectedEventType)) return true;
+                return Boolean(this.selectedSubEvent);
             }
 
             navigateToSpecificForm() {
-                if (!this.validateForm()) return;
+                if (!this.validateForm()) {
+                    const eventTypeError = document.getElementById('eventTypeError');
+                    if (eventTypeError) {
+                        eventTypeError.style.display = 'block';
+                        eventTypeError.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    }
+                    return;
+                }
 
                 const data = {
                     flightEventType: this.selectedEventType,

--- a/flight_info.html
+++ b/flight_info.html
@@ -29,89 +29,82 @@
         <!-- Card con datos básicos del vuelo -->
         <div class="card">
             <div class="card-header">
-                <h2>Datos Básicos del Evento</h2>
-                <p>Complete la información específica del evento reportado</p>
+                <h2>Información del vuelo</h2>
+                <p>Aporta los datos que permitan ubicar el evento en el itinerario y la operación.</p>
             </div>
             <div class="card-body">
                 <div class="alert alert-info">
-                    <strong>Información del evento:</strong> Proporcione los datos disponibles. Los campos marcados con * son obligatorios.
+                    <strong>Importante:</strong> Los campos con <span class="required">*</span> son obligatorios. Los que muestran <span class="optional-badge">Opcional</span> pueden omitirse si no cuentas con la información.
                 </div>
 
                 <form id="flightDetailsForm">
-                    <div class="form-grid">
+                    <section class="form-section">
+                        <h3>Momento del evento <span class="required">*</span></h3>
+                        <p class="section-description">Registra fecha y hora local para correlacionar con registros de vuelo y meteorología.</p>
+                        <div class="form-grid">
+                            <div class="form-group">
+                                <label for="flightDate">Fecha del evento <span class="required">*</span></label>
+                                <input type="date" id="flightDate" name="flightDate" max="" required>
+                                <p class="microcopy">Utiliza el calendario para evitar errores de formato.</p>
+                                <span class="error-message" id="flightDateError"></span>
+                            </div>
 
-                         <div class="form-group">
-                            <label for="flightDate">Fecha del Evento <span class="required">*</span></label>
-                            <input type="date" id="flightDate" name="flightDate" max="" required>
-                            <span class="error-message" id="flightDateError"></span>
+                            <div class="form-group">
+                                <label for="flightTime">Hora del evento (local) <span class="required">*</span></label>
+                                <input type="time" id="flightTime" name="flightTime" placeholder="HH:MM" required>
+                                <p class="microcopy">Si no recuerdas los minutos exactos, aproxima al tramo de 5 minutos más cercano.</p>
+                                <span class="error-message" id="flightTimeError"></span>
+                            </div>
                         </div>
+                    </section>
 
-                        <div class="form-group">
-                            <label for="flightTime">Hora del Evento (Local) <span class="required">*</span></label>
-                            <input type="time" id="flightTime" name="flightTime" placeholder="HH:MM" required>
-                            <span class="error-message" id="flightTimeError"></span>
+                    <section class="form-section">
+                        <h3>Identificadores de vuelo</h3>
+                        <p class="section-description">Estos datos ayudan a vincular el reporte con planes de vuelo y bitácoras.</p>
+                        <div class="form-grid">
+                            <div class="form-group">
+                                <label for="flightNumber">Número de vuelo <span class="optional-badge">Opcional</span></label>
+                                <input type="text" id="flightNumber" name="flightNumber"
+                                       placeholder="Ejemplo: AV123"
+                                       maxlength="8">
+                                <p class="microcopy">Formato recomendado: dos letras de aerolínea y de 1 a 4 dígitos.</p>
+                                <span class="error-message" id="flightNumberError"></span>
+                            </div>
+
+                            <div class="form-group">
+                                <label for="aircraftRegistration">Matrícula de la aeronave <span class="optional-badge">Opcional</span></label>
+                                <input type="text" id="aircraftRegistration" name="aircraftRegistration"
+                                       placeholder="Ejemplo: N401AV"
+                                       maxlength="10">
+                                <p class="microcopy">Solo letras y números, sin guiones ni espacios.</p>
+                                <span class="error-message" id="aircraftRegistrationError"></span>
+                            </div>
                         </div>
-                        <div class="form-group">
-                            <label for="flightNumber">Número de Vuelo </label>
-                            <input type="text" id="flightNumber" name="flightNumber"
-                                   placeholder="Ejemplo: AV123" 
-                                   pattern="^[A-Z]{2}[0-9]{1,4}$"
-                                   maxlength="8">
-                            <span class="error-message" id="flightNumberError"></span>
+                    </section>
+
+                    <section class="form-section">
+                        <h3>Ruta y base de operación</h3>
+                        <p class="section-description">Incluye los aeropuertos para comprender el contexto operacional.</p>
+                        <div class="form-grid">
+                            <div class="form-group">
+                                <label for="origin">Aeropuerto de origen <span class="optional-badge">Opcional</span></label>
+                                <input type="text" id="origin" name="origin"
+                                       placeholder="Código IATA: BOG, MDE, CLO..."
+                                       maxlength="3">
+                                <p class="microcopy">Se aceptan códigos IATA en mayúsculas.</p>
+                                <span class="error-message" id="originError"></span>
+                            </div>
+
+                            <div class="form-group">
+                                <label for="destination">Aeropuerto de destino <span class="optional-badge">Opcional</span></label>
+                                <input type="text" id="destination" name="destination"
+                                       placeholder="Código IATA: BOG, MDE, CLO..."
+                                       maxlength="3">
+                                <p class="microcopy">Se aceptan códigos IATA en mayúsculas.</p>
+                                <span class="error-message" id="destinationError"></span>
+                            </div>
                         </div>
-
-                        <div class="form-group">
-                            <label for="aircraftRegistration">Matrícula de la Aeronave </label>
-                            <input type="text" id="aircraftRegistration" name="aircraftRegistration"
-                                   placeholder="Ejemplo: N401AV" 
-                                   maxlength="10">
-                            <span class="error-message" id="aircraftRegistrationError"></span>
-                        </div>
-
-                        <div class="form-group">
-                            <label for="origin">Aeropuerto de Origen </label>
-                            <input type="text" id="origin" name="origin" 
-                                   placeholder="Código IATA: BOG, MDE, CLO..." 
-                                   pattern="^[A-Z]{3}$"
-                                   maxlength="3">
-                            <span class="error-message" id="originError"></span>
-                        </div>
-
-                        <div class="form-group">
-                            <label for="destination">Aeropuerto de Destino </label>
-                            <input type="text" id="destination" name="destination" 
-                                   placeholder="Código IATA: BOG, MDE, CLO..." 
-                                   pattern="^[A-Z]{3}$"
-                                   maxlength="3">
-                            <span class="error-message" id="destinationError"></span>
-                        </div>
-
-                       
-
-                       <!--
-
-                        <div class="form-group">
-                            <label for="flightPhase">Fase de Vuelo</label>
-                            <select id="flightPhase" name="flightPhase">
-                                <option value="">Seleccione una fase</option>
-                                <option value="pre_flight">Pre-vuelo</option>
-                                <option value="taxi_out">Rodaje de salida</option>
-                                <option value="takeoff">Despegue</option>
-                                <option value="climb">Ascenso</option>
-                                <option value="cruise">Crucero</option>
-                                <option value="descent">Descenso</option>
-                                <option value="approach">Aproximación</option>
-                                <option value="landing">Aterrizaje</option>
-                                <option value="taxi_in">Rodaje de llegada</option>
-                                <option value="post_flight">Post-vuelo</option>
-                                <option value="ground">En tierra</option>
-                            </select>
-                        </div>
-
-                        -->
-
-                        
-                    </div>
+                    </section>
 
                     <div class="form-actions">
                         <button type="button" class="btn btn-secondary" id="backBtn">Regresar</button>
@@ -132,8 +125,8 @@
 
         document.addEventListener('DOMContentLoaded', () => {
             init();
-            setupFlightValidation();
-            setupButtons();
+            const runValidation = setupFlightValidation();
+            setupButtons(runValidation);
             setTodayAsDefault();
         });
 
@@ -155,53 +148,78 @@
         // --- Validación y recolección de datos ---
         function setupFlightValidation() {
             const requiredFields = [
-                { id: 'flightNumber', pattern: /^[A-Z]{2}[0-9]{1,4}$/i, message: 'Formato: XX123 (2 letras + números)' },
-                { id: 'aircraftRegistration', pattern: /^[A-Z0-9]+$/i, message: 'Solo se admiten letras mayúsculas y números' },
-                { id: 'origin', pattern: /^[A-Z]{3}$/i, message: 'Código IATA de 3 letras' },
-                { id: 'destination', pattern: /^[A-Z]{3}$/i, message: 'Código IATA de 3 letras' },
-                { id: 'flightDate', pattern: /.+/, message: 'Fecha requerida' }
+                { id: 'flightDate', validator: value => value !== '', message: 'La fecha es obligatoria' },
+                { id: 'flightTime', validator: value => /^([01]\d|2[0-3]):[0-5]\d$/.test(value), message: 'Formato HH:MM requerido' }
             ];
 
             const optionalFields = [
-                { id: 'runway', pattern: /^[0-9]{2}[LRC]?$/i, message: 'Formato: 13L, 31R, 07' }
+                { id: 'flightNumber', validator: value => /^[A-Z]{2}\d{1,4}$/.test(value), message: 'Formato: XX123 (2 letras + números)' },
+                { id: 'aircraftRegistration', validator: value => /^[A-Z0-9]+$/.test(value), message: 'Solo letras mayúsculas y números' },
+                { id: 'origin', validator: value => /^[A-Z]{3}$/.test(value), message: 'Código IATA de 3 letras' },
+                { id: 'destination', validator: value => /^[A-Z]{3}$/.test(value), message: 'Código IATA de 3 letras' }
             ];
 
-            function setupFieldValidation(fields, required = false) {
-                fields.forEach(field => {
-                    const input = document.getElementById(field.id);
-                    const errorSpan = document.getElementById(field.id + 'Error');
-                    if (!input || !errorSpan) return;
+            function attachValidation(field, isRequired = false) {
+                const input = document.getElementById(field.id);
+                const errorSpan = document.getElementById(`${field.id}Error`);
+                if (!input || !errorSpan) return () => true;
 
-                    const validate = () => {
-                        let value = input.value.trim();
-                        if (input.type === 'text' && value) value = value.toUpperCase();
+                const validate = () => {
+                    let value = input.value.trim();
+                    if (input.type === 'text') {
+                        value = value.toUpperCase();
                         input.value = value;
+                    }
 
-                        if (!required && !value) { errorSpan.textContent=''; errorSpan.style.display='none'; input.classList.remove('invalid'); return true; }
-                        if (required && !value) { errorSpan.textContent='Campo requerido'; errorSpan.style.display='block'; input.classList.add('invalid'); return false; }
-                        if (value && !field.pattern.test(value)) { errorSpan.textContent=field.message; errorSpan.style.display='block'; input.classList.add('invalid'); return false; }
-
-                        errorSpan.textContent='';
-                        errorSpan.style.display='none';
+                    if (!value && !isRequired) {
+                        errorSpan.textContent = '';
+                        errorSpan.style.display = 'none';
                         input.classList.remove('invalid');
                         return true;
-                    };
+                    }
 
-                    input.addEventListener('input', validate);
-                });
+                    const isValid = field.validator(value);
+                    if (!isValid) {
+                        errorSpan.textContent = isRequired && !value ? 'Campo requerido' : field.message;
+                        errorSpan.style.display = 'block';
+                        input.classList.add('invalid');
+                        return false;
+                    }
+
+                    errorSpan.textContent = '';
+                    errorSpan.style.display = 'none';
+                    input.classList.remove('invalid');
+                    return true;
+                };
+
+                input.addEventListener('input', validate);
+                input.addEventListener('blur', validate);
+                return validate;
             }
 
-            setupFieldValidation(requiredFields, true);
-            setupFieldValidation(optionalFields, false);
+            const validators = [];
+            requiredFields.forEach(field => validators.push(attachValidation(field, true)));
+            optionalFields.forEach(field => validators.push(attachValidation(field, false)));
+
+            return () => validators.every(fn => fn());
         }
 
         // --- Botones ---
-        function setupButtons() {
+        function setupButtons(runValidation) {
             const continueBtn = document.getElementById('continueBtn');
             const backBtn = document.getElementById('backBtn');
-            continueBtn.disabled = false; // solo ejemplo: activamos directamente
+            const form = document.getElementById('flightDetailsForm');
+
+            const toggleContinue = () => {
+                const valid = runValidation();
+                continueBtn.disabled = !valid;
+            };
+
+            form.addEventListener('input', toggleContinue);
+            setTimeout(toggleContinue, 50);
 
             continueBtn.addEventListener('click', () => {
+                if (continueBtn.disabled) return;
                 window.location.href = 'reporter_info.html';
             });
             backBtn.addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <div class="container">
         <div class="progress-indicator">
             <div class="progress-bar">
-                <div class="progress-fill" id="progressFill" style="width: 50%;"></div>
+                <div class="progress-fill" id="progressFill"></div>
             </div>
             <div class="step-text">Paso 1 de 6: Selección de Proceso Operacional</div>
         </div>
@@ -105,6 +105,64 @@
                         <div class="area-description">Eventos relacionados con la gestión y procesos internos de la organización</div>
                     </div>
                     -->
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="intro-overlay" id="introOverlay" role="dialog" aria-modal="true" aria-labelledby="introTitle">
+        <div class="intro-dialog">
+            <header>
+                <h2 id="introTitle">Cómo completaremos tu reporte en 6 pasos</h2>
+                <p>Revisa rápidamente el flujo antes de iniciar. Podrás consultarlo más tarde desde el menú de ayuda.</p>
+            </header>
+            <div class="intro-body">
+                <div class="steps-list">
+                    <div class="step-item">
+                        <div class="step-number">1</div>
+                        <div class="step-text">
+                            <strong>Selecciona el proceso operacional.</strong>
+                            <span>Indica el contexto donde ocurrió el evento o peligro.</span>
+                        </div>
+                    </div>
+                    <div class="step-item">
+                        <div class="step-number">2</div>
+                        <div class="step-text">
+                            <strong>Define el tipo de evento.</strong>
+                            <span>Elegiremos juntos el subtipo correspondiente en la misma vista.</span>
+                        </div>
+                    </div>
+                    <div class="step-item">
+                        <div class="step-number">3</div>
+                        <div class="step-text">
+                            <strong>Confirma los datos clave.</strong>
+                            <span>Validaremos fase, condiciones y responsables involucrados.</span>
+                        </div>
+                    </div>
+                    <div class="step-item">
+                        <div class="step-number">4</div>
+                        <div class="step-text">
+                            <strong>Redacta el reporte guiado.</strong>
+                            <span>Completarás bloques cortos con ayudas y validación automática.</span>
+                        </div>
+                    </div>
+                    <div class="step-item">
+                        <div class="step-number">5</div>
+                        <div class="step-text">
+                            <strong>Registra la información del vuelo.</strong>
+                            <span>Campos obligatorios y opcionales claramente identificados.</span>
+                        </div>
+                    </div>
+                    <div class="step-item">
+                        <div class="step-number">6</div>
+                        <div class="step-text">
+                            <strong>Agrega tus datos de contacto.</strong>
+                            <span>Con microcopias y privacidad transparente para cerrar el reporte.</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="intro-actions">
+                    <button class="btn" id="introDismiss">Entendido</button>
                 </div>
             </div>
         </div>

--- a/js/main.js
+++ b/js/main.js
@@ -7,6 +7,7 @@ class SafetyReportSystem {
     init() {
         this.bindEvents();
         this.updateProgress(16.67);
+        this.setupIntroOverlay();
     }
 
     bindEvents() {
@@ -16,6 +17,40 @@ class SafetyReportSystem {
                 this.selectArea(card);
                 this.proceedToSpecificForm(); // 🔹 redirige al instante
             });
+        });
+    }
+
+    setupIntroOverlay() {
+        const overlay = document.getElementById('introOverlay');
+        const dismissBtn = document.getElementById('introDismiss');
+        if (!overlay || !dismissBtn) return;
+
+        const INTRO_FLAG = 'safety_intro_seen';
+        const shouldShow = sessionStorage.getItem(INTRO_FLAG) !== 'true';
+
+        if (shouldShow) {
+            overlay.classList.add('show');
+            document.body.style.overflow = 'hidden';
+        }
+
+        const closeOverlay = () => {
+            overlay.classList.remove('show');
+            sessionStorage.setItem(INTRO_FLAG, 'true');
+            document.body.style.overflow = '';
+        };
+
+        dismissBtn.addEventListener('click', closeOverlay);
+
+        overlay.addEventListener('click', (event) => {
+            if (event.target === overlay) {
+                closeOverlay();
+            }
+        });
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && overlay.classList.contains('show')) {
+                closeOverlay();
+            }
         });
     }
 

--- a/reporter_info.html
+++ b/reporter_info.html
@@ -27,53 +27,71 @@
 
         <div class="card">
             <div class="card-header">
-                <h2>Información del Reportante</h2>
-                <p>Complete los datos de la persona que reporta el evento de seguridad operacional</p>
+                <h2>Información del reportante</h2>
+                <p>Estos datos se usan únicamente para aclaraciones y seguimiento dentro del programa de seguridad operacional.</p>
             </div>
             <div class="card-body">
                 <div class="alert alert-info">
-                    <strong>Confidencialidad:</strong> La información proporcionada será tratada según la politica de confidencialiad y no punitividad.
-                     de la organización.
+                    <strong>Confidencialidad:</strong> Tu reporte se gestiona bajo políticas de no represalia y resguardo de datos personales.
                 </div>
 
                 <form id="reporterForm">
-                    <div class="form-grid">
-                        <div class="form-group">
-                            <label for="firstName">Nombres <span class="required">*</span></label>
-                            <input type="text" id="firstName" name="firstName" required placeholder="Juan" pattern="^[A-Za-zÀ-ÿ\s]+$">
-                            <span class="error-message" id="firstNameError"></span>
+                    <section class="form-section">
+                        <h3>Identificación personal</h3>
+                        <p class="section-description">Indica tu nombre tal como aparece en registros internos para facilitar el contacto.</p>
+                        <div class="form-grid">
+                            <div class="form-group">
+                                <label for="firstName">Nombres <span class="required">*</span></label>
+                                <input type="text" id="firstName" name="firstName" required placeholder="Juan Carlos">
+                                <p class="microcopy">Incluye segundo nombre si aplica.</p>
+                                <span class="error-message" id="firstNameError"></span>
+                            </div>
+                            <div class="form-group">
+                                <label for="lastName">Apellidos <span class="required">*</span></label>
+                                <input type="text" id="lastName" name="lastName" required placeholder="Pérez Gómez">
+                                <p class="microcopy">Usa solo letras y espacios.</p>
+                                <span class="error-message" id="lastNameError"></span>
+                            </div>
                         </div>
-                        <div class="form-group">
-                            <label for="lastName">Apellidos <span class="required">*</span></label>
-                            <input type="text" id="lastName" name="lastName" required placeholder="Pérez" pattern="^[A-Za-zÀ-ÿ\s]+$">
-                            <span class="error-message" id="lastNameError"></span>
-                        </div>
-                        <div class="form-group">
-                            <label for="email">Correo Electrónico <span class="required">*</span></label>
-                            <input type="email" id="email" name="email" required placeholder="correo@ejemplo.com">
-                            <span class="error-message" id="emailError"></span>
-                        </div>
-                        <div class="form-group">
-                            <label for="email">Área a la que pertenezco</label>
-                            <input type="text" id="area_reportante" name="area_reportante" maxlength="40">
-                            <span class="error-message" id="areaError"></span>
-                        </div>
-                        <div class="form-group">
-                            <label for="email">Base a la que pertenezco</label>
-                            <input type="text" id="base_reportante" name="base_reportante" pattern="^[A-Z]{3}$" 
-                            placeholder="Código IATA: BOG, MDE, CLO..."  maxlength="3" style="text-transform: uppercase;">
-                            <span class="error-message" id="baseError"></span>
-                        </div>
+                    </section>
 
-                        <!--
-                        <div class="form-group">
-                            <label for="phone">Teléfono <span class="required">*</span></label>
-                            <input type="tel" id="phone" name="phone" required placeholder="3001234567" pattern="^\d{7,15}$">
-                            <span class="error-message" id="phoneError"></span>
+                    <section class="form-section">
+                        <h3>Contacto preferido</h3>
+                        <p class="section-description">Definiremos cómo avisarte sobre avances o aclaraciones del reporte.</p>
+                        <div class="form-grid">
+                            <div class="form-group">
+                                <label for="email">Correo electrónico <span class="required">*</span></label>
+                                <input type="email" id="email" name="email" required placeholder="nombre.apellido@empresa.com">
+                                <p class="microcopy">Recibirás un acuse de recibido y futuras comunicaciones en esta dirección.</p>
+                                <span class="error-message" id="emailError"></span>
+                            </div>
+                            <div class="form-group">
+                                <label for="phone">Teléfono móvil <span class="optional-badge">Opcional</span></label>
+                                <input type="tel" id="phone" name="phone" placeholder="3001234567" maxlength="15">
+                                <p class="microcopy">Incluye solo números, sin espacios ni guiones.</p>
+                                <span class="error-message" id="phoneError"></span>
+                            </div>
                         </div>
-                    -->
+                    </section>
 
-                    </div>
+                    <section class="form-section">
+                        <h3>Contexto en la organización</h3>
+                        <p class="section-description">Estos campos nos ayudan a segmentar tendencias por áreas operativas.</p>
+                        <div class="form-grid">
+                            <div class="form-group">
+                                <label for="area_reportante">Área o dependencia <span class="optional-badge">Opcional</span></label>
+                                <input type="text" id="area_reportante" name="area_reportante" maxlength="40" placeholder="Ejemplo: Operaciones de vuelo">
+                                <p class="microcopy">Puedes indicar tu cargo o la dependencia a la que perteneces.</p>
+                                <span class="error-message" id="area_reportanteError"></span>
+                            </div>
+                            <div class="form-group">
+                                <label for="base_reportante">Base o estación <span class="optional-badge">Opcional</span></label>
+                                <input type="text" id="base_reportante" name="base_reportante" maxlength="3" placeholder="Código IATA: BOG, MDE, CLO..." style="text-transform: uppercase;">
+                                <p class="microcopy">Usa el código IATA de tres letras de tu base principal.</p>
+                                <span class="error-message" id="base_reportanteError"></span>
+                            </div>
+                        </div>
+                    </section>
                 </form>
                 <div class="form-actions">
                     <button type="button" class="btn" id="continueBtn" disabled>Finalizar</button>
@@ -133,52 +151,85 @@
             }
 
             setupFieldValidation() {
-                const fields = [
-                    { id: 'firstName', name: 'Nombre', pattern: /^[A-Za-zÀ-ÿ\s]+$/ },
-                    { id: 'base_reportante', name: 'Base', pattern: /^[A-Z]{3}$/ },
-                    { id: 'lastName', name: 'Apellido', pattern: /^[A-Za-zÀ-ÿ\s]+$/ },
-                    { id: 'email', name: 'Correo', pattern: /^[^\s@]+@[^\s@]+\.[^\s@]+$/ },
-                    { id: 'phone', name: 'Teléfono', pattern: /^\d{7,15}$/ }
+                this.fieldConfigs = [
+                    { id: 'firstName', label: 'Nombres', pattern: /^[A-Za-zÀ-ÿ\s]+$/, required: true },
+                    { id: 'lastName', label: 'Apellidos', pattern: /^[A-Za-zÀ-ÿ\s]+$/, required: true },
+                    { id: 'email', label: 'Correo electrónico', pattern: /^[^\s@]+@[^\s@]+\.[^\s@]+$/, required: true },
+                    { id: 'phone', label: 'Teléfono móvil', pattern: /^\d{7,15}$/, required: false },
+                    { id: 'area_reportante', label: 'Área o dependencia', minLength: 3, required: false },
+                    { id: 'base_reportante', label: 'Base o estación', pattern: /^[A-Z]{3}$/, required: false }
                 ];
 
-                fields.forEach(field => {
-                    const input = document.getElementById(field.id);
-                    const errorSpan = document.getElementById(field.id + 'Error');
+                this.fieldConfigs.forEach(config => {
+                    const input = document.getElementById(config.id);
+                    if (!input) return;
 
-                    if (!input || !errorSpan) return;
-
-                    const validate = () => {
-                        const value = input.value.trim();
-                        if (!value) {
-                            errorSpan.textContent = `${field.name} requerido`;
-                            errorSpan.style.display = 'block';
-                            input.classList.add('invalid');
-                            return false;
-                        }
-                        if (!field.pattern.test(value)) {
-                            errorSpan.textContent = `Formato inválido`;
-                            errorSpan.style.display = 'block';
-                            input.classList.add('invalid');
-                            return false;
-                        }
-                        errorSpan.textContent = '';
-                        errorSpan.style.display = 'none';
-                        input.classList.remove('invalid');
-                        return true;
+                    const handleValidation = () => {
+                        this.validateSingleField(config);
+                        this.validateForm();
                     };
 
-                    input.addEventListener('input', () => {
-                        validate();
-                        this.validateForm();
-                    });
-                    input.addEventListener('blur', validate);
+                    if (config.id === 'phone') {
+                        input.addEventListener('input', () => {
+                            input.value = input.value.replace(/\D/g, '');
+                            handleValidation();
+                        });
+                    } else {
+                        input.addEventListener('input', handleValidation);
+                    }
+                    input.addEventListener('blur', () => this.validateSingleField(config));
                 });
+            }
+
+            validateSingleField(config) {
+                const input = document.getElementById(config.id);
+                const errorSpan = document.getElementById(`${config.id}Error`);
+                if (!input || !errorSpan) return true;
+
+                let value = input.value.trim();
+                if (config.id === 'base_reportante') {
+                    value = value.toUpperCase();
+                    input.value = value;
+                }
+
+                if (!value) {
+                    if (config.required) {
+                        errorSpan.textContent = `${config.label} es obligatorio`;
+                        errorSpan.style.display = 'block';
+                        input.classList.add('invalid');
+                        return false;
+                    }
+
+                    errorSpan.textContent = '';
+                    errorSpan.style.display = 'none';
+                    input.classList.remove('invalid');
+                    return true;
+                }
+
+                if (config.minLength && value.length < config.minLength) {
+                    errorSpan.textContent = `Mínimo ${config.minLength} caracteres`;
+                    errorSpan.style.display = 'block';
+                    input.classList.add('invalid');
+                    return false;
+                }
+
+                if (config.pattern && !config.pattern.test(value)) {
+                    errorSpan.textContent = 'Formato inválido';
+                    errorSpan.style.display = 'block';
+                    input.classList.add('invalid');
+                    return false;
+                }
+
+                errorSpan.textContent = '';
+                errorSpan.style.display = 'none';
+                input.classList.remove('invalid');
+                return true;
             }
 
             bindEvents() {
                 const form = document.getElementById('reporterForm');
                 if (form) {
-                    const inputs = form.querySelectorAll('input[required]');
+                    const inputs = form.querySelectorAll('input');
                     inputs.forEach(input => {
                         input.addEventListener('input', () => this.validateForm());
                     });
@@ -190,17 +241,9 @@
             }
 
             validateForm() {
-                const form = document.getElementById('reporterForm');
-                if (!form) return false;
+                if (!this.fieldConfigs) return false;
 
-                let isValid = true;
-                const requiredInputs = form.querySelectorAll('input[required]');
-                
-                requiredInputs.forEach(input => {
-                    if (!input.value.trim() || input.classList.contains('invalid')) {
-                        isValid = false;
-                    }
-                });
+                const isValid = this.fieldConfigs.every(config => this.validateSingleField(config));
 
                 const continueBtn = document.getElementById('continueBtn');
                 if (continueBtn) continueBtn.disabled = !isValid;

--- a/title_desc.html
+++ b/title_desc.html
@@ -29,27 +29,45 @@
         <!-- Card: Información del Reporte -->
         <div class="card">
             <div class="card-header">
-                <h2>Información del Reporte</h2>
-                <p>Complete los detalles específicos del evento de seguridad operacional reportado</p>
+                <h2>Narrativa guiada del reporte</h2>
+                <p>Responde cada bloque para construir un relato claro y accionable sobre el evento.</p>
             </div>
             <div class="card-body">
                 <div class="alert alert-info">
-                    <strong>Importante:</strong> Proporcione la mayor cantidad de detalles posible.
+                    <strong>Consejo:</strong> Usa lenguaje concreto y evita siglas poco comunes para facilitar el análisis.
                 </div>
                 <form id="reportDetailsForm">
-                    <div class="form-grid">
-                        <div class="form-group full-width">
-                            <label for="reportTitle">Título del Reporte <span class="required">*</span></label>
-                            <input type="text" id="reportTitle" name="reportTitle" maxlength="150"
-                                   placeholder="Ejemplo: Incidente durante aproximación en condiciones meteorológicas adversas">
-                            <span class="error-message" id="reportTitleError"></span>
+                    <div class="guided-blocks">
+                        <div class="guided-block">
+                            <h3>1. Resumen ejecutivo <span class="required">*</span></h3>
+                            <p>Describe en una frase qué ocurrió y su impacto inmediato.</p>
+                            <input type="text" id="reportSummary" name="reportSummary" maxlength="160"
+                                   placeholder="Ejemplo: Aproximación inestable obligó a ejecutar go-around en BOG.">
+                            <span class="error-message" id="reportSummaryError"></span>
                         </div>
 
-                        <div class="form-group full-width">
-                            <label for="reportDescription">Descripción Detallada del Evento <span class="required">*</span></label>
-                            <textarea id="reportDescription" name="reportDescription" rows="12" minlength="20"
-                                      placeholder="Describa detalladamente el evento ocurrido"></textarea>
-                            <span class="error-message" id="reportDescriptionError"></span>
+                        <div class="guided-block">
+                            <h3>2. Desarrollo cronológico <span class="required">*</span></h3>
+                            <p>Detalla la secuencia de eventos, incluyendo decisiones, comunicaciones y condiciones relevantes.</p>
+                            <textarea id="reportTimeline" name="reportTimeline" rows="7" minlength="80"
+                                      placeholder="Relata paso a paso lo sucedido desde el inicio hasta el cierre del evento."></textarea>
+                            <span class="error-message" id="reportTimelineError"></span>
+                        </div>
+
+                        <div class="guided-block">
+                            <h3>3. Factores contribuyentes <span class="required">*</span></h3>
+                            <p>Indica elementos técnicos, humanos o ambientales que influyeron en el evento.</p>
+                            <textarea id="reportFactors" name="reportFactors" rows="5" minlength="40"
+                                      placeholder="Ejemplo: Condiciones meteorológicas IMC, fatiga en tripulación, NOTAM no actualizado."></textarea>
+                            <span class="error-message" id="reportFactorsError"></span>
+                        </div>
+
+                        <div class="guided-block">
+                            <h3>4. Acciones y recomendaciones <span class="optional-badge">Opcional</span></h3>
+                            <p>Comparte acciones tomadas, lecciones aprendidas o sugerencias para mitigar recurrencias.</p>
+                            <textarea id="reportActions" name="reportActions" rows="4" maxlength="600"
+                                      placeholder="Acciones inmediatas, seguimiento requerido o propuestas de mejora."></textarea>
+                            <span class="error-message" id="reportActionsError"></span>
                         </div>
                     </div>
                 </form>
@@ -97,35 +115,63 @@
         document.addEventListener('DOMContentLoaded', init);
 
         function setupValidation() {
-            const titleInput = document.getElementById('reportTitle');
-            const descInput = document.getElementById('reportDescription');
             const continueBtn = document.getElementById('continueBtn');
+            const fields = [
+                { id: 'reportSummary', min: 20, label: 'Resumen ejecutivo' },
+                { id: 'reportTimeline', min: 80, label: 'Desarrollo cronológico' },
+                { id: 'reportFactors', min: 40, label: 'Factores contribuyentes' }
+            ];
 
-            function validateField(input, minLength=1) {
-                const errorSpan = document.getElementById(input.id + 'Error');
-                if(input.value.trim().length < minLength){
-                    errorSpan.textContent = minLength === 1 ? 'Campo requerido' : `Mínimo ${minLength} caracteres`;
+            const optionalFields = [
+                { id: 'reportActions', min: 0, label: 'Acciones y recomendaciones' }
+            ];
+
+            function validateField(input, minLength, label, optional = false) {
+                const value = input.value.trim();
+                const errorSpan = document.getElementById(`${input.id}Error`);
+
+                if (!optional && value.length < minLength) {
+                    errorSpan.textContent = value.length === 0 ? `${label} es obligatorio` : `Mínimo ${minLength} caracteres`;
+                    errorSpan.style.display = 'block';
                     input.classList.add('invalid');
                     return false;
-                } else {
-                    errorSpan.textContent = '';
-                    input.classList.remove('invalid');
-                    return true;
                 }
+
+                if (optional && value && value.length < minLength) {
+                    errorSpan.textContent = `Mínimo ${minLength} caracteres`;
+                    errorSpan.style.display = 'block';
+                    input.classList.add('invalid');
+                    return false;
+                }
+
+                errorSpan.textContent = '';
+                errorSpan.style.display = 'none';
+                input.classList.remove('invalid');
+                return true;
             }
 
             function validateForm() {
-                const validTitle = validateField(titleInput);
-                const validDesc = validateField(descInput, 20);
-                const isValid = validTitle && validDesc;
+                const requiredValid = fields.every(field => {
+                    const element = document.getElementById(field.id);
+                    return validateField(element, field.min, field.label);
+                });
 
-                continueBtn.disabled = !isValid;
-                continueBtn.style.opacity = isValid ? '1' : '0.5';
-                continueBtn.style.cursor = isValid ? 'pointer' : 'not-allowed';
+                optionalFields.forEach(field => {
+                    const element = document.getElementById(field.id);
+                    validateField(element, field.min, field.label, true);
+                });
+
+                continueBtn.disabled = !requiredValid;
+                continueBtn.style.opacity = requiredValid ? '1' : '0.5';
+                continueBtn.style.cursor = requiredValid ? 'pointer' : 'not-allowed';
             }
 
-            titleInput.addEventListener('input', validateForm);
-            descInput.addEventListener('input', validateForm);
+            [...fields, ...optionalFields].forEach(({ id }) => {
+                const element = document.getElementById(id);
+                element.addEventListener('input', validateForm);
+                element.addEventListener('blur', validateForm);
+            });
+
             setTimeout(validateForm, 50);
         }
 
@@ -180,11 +226,21 @@
             const continueBtn = document.getElementById('continueBtn');
             backBtn.addEventListener('click', () => window.history.back());
             continueBtn.addEventListener('click', () => {
-                const titleInput = document.getElementById('reportTitle');
-                const descInput = document.getElementById('reportDescription');
-                if(!titleInput.value.trim() || descInput.value.trim().length<20){ return; }
+                const summary = document.getElementById('reportSummary');
+                const timeline = document.getElementById('reportTimeline');
+                const factors = document.getElementById('reportFactors');
+                const actions = document.getElementById('reportActions');
+
+                if (continueBtn.disabled) return;
+
                 const existingData = JSON.parse(sessionStorage.getItem('safetyReportData')||'{}');
-                const newData = {...existingData, report:{title:titleInput.value, description:descInput.value}};
+                const narrative = {
+                    summary: summary.value.trim(),
+                    timeline: timeline.value.trim(),
+                    factors: factors.value.trim(),
+                    actions: actions.value.trim()
+                };
+                const newData = { ...existingData, report: narrative };
                 sessionStorage.setItem('safetyReportData', JSON.stringify(newData));
                 window.location.href='flight_info_mandatory.html';
             });


### PR DESCRIPTION
## Summary
- add a six-step introductory overlay to the landing step to orient reporters
- restructure the flight event selection screen to expose subtype options inline with direct validation
- reorganize narrative, flight information, and reporter details into guided sections with clear optional states and helper text, updating shared styles to support the experience

## Testing
- No automated tests were run (static HTML/CSS/JS changes)


------
https://chatgpt.com/codex/tasks/task_e_68d755f6c8d883268a766ee926f2b124